### PR TITLE
Fix Gemini setup and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+GEMINI_API_KEY=your_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Next.js build output
+.next/
+
+# Node dependencies
+node_modules/
+
+# Environment files and secrets
+.env
+.env.*
+!*.example
+*.local
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # Eidos
+
+Eidos is a Next.js application that showcases AI‑assisted data visualisation.
+
+## Installation
+
+1. Copy `.env.example` to `.env.local` and add your Gemini API key.
+2. Install dependencies using **pnpm**:
+   ```bash
+   pnpm install
+   ```
+
+## Usage
+
+Start the development server with:
+```bash
+pnpm dev
+```
+
+Build and launch a production version with:
+```bash
+pnpm build
+pnpm start
+```
+
+## Project structure
+
+- `app/` – Next.js routes
+- `components/` – React components including the visualisation canvas
+- `services/` – Helper functions interacting with the Gemini API
+- `styles/` – Tailwind CSS configuration
+
+## Environment variables
+
+The project requires a Gemini API key:
+
+```
+GEMINI_API_KEY=your_api_key_here
+```
+
+Create an `.env.local` file (ignored by Git) and set the value before running the application.

--- a/components/DataVisualizationCanvas.tsx
+++ b/components/DataVisualizationCanvas.tsx
@@ -10,6 +10,7 @@ import {
   ScatterChart,
   Scatter,
   PieChart as RechartsPieChart,
+  Pie,
   Cell,
   LineChart,
   Line,
@@ -125,11 +126,11 @@ export default function DataVisualizationCanvas({ data, columns, visualizationTy
                   color: "#fff",
                 }}
               />
-              <RechartsPieChart dataKey="value" data={chartData} cx="50%" cy="50%" outerRadius={120}>
+              <Pie dataKey="value" data={chartData} cx="50%" cy="50%" outerRadius={120}>
                 {chartData.map((entry, index) => (
                   <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                 ))}
-              </RechartsPieChart>
+              </Pie>
             </RechartsPieChart>
           </ResponsiveContainer>
         )

--- a/services/aiAnalysisService.ts
+++ b/services/aiAnalysisService.ts
@@ -1,6 +1,7 @@
 import { GoogleGenerativeAI } from "@google/generative-ai"
 
-const genAI = new GoogleGenerativeAI("AIzaSyB_lBRH0ja-p9-8Xzvzv8RfTU6z5QHKRWs")
+// Use API key from environment variables to avoid exposing secrets in source
+const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || "")
 
 export interface DataAnalysis {
   dataType: "numerical" | "categorical" | "mixed" | "temporal"
@@ -145,7 +146,7 @@ export async function generateVisualizationSuggestion(
   userRequest: string,
 ): Promise<string> {
   try {
-    const model = genAI.getGenerativeAI({ model: "gemini-pro" })
+    const model = genAI.getGenerativeModel({ model: "gemini-pro" })
 
     const prompt = `
     L'utilisateur a des données CSV avec les colonnes: ${columns.join(", ")}

--- a/services/geminiChatService.ts
+++ b/services/geminiChatService.ts
@@ -1,6 +1,7 @@
 import { GoogleGenerativeAI } from "@google/generative-ai"
 
-const genAI = new GoogleGenerativeAI("AIzaSyB_lBRH0ja-p9-8Xzvzv8RfTU6z5QHKRWs")
+// Read API key from environment to keep secrets out of the repository
+const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || "")
 
 export interface ChatResponse {
   message: string


### PR DESCRIPTION
## Summary
- hide the Gemini API key behind an environment variable
- use `getGenerativeModel` correctly
- correct pie chart rendering
- add `.gitignore` and example env file
- document project usage in README

## Testing
- `pnpm run build` *(fails: Local package.json exists, but node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842a51c4edc832b99282c1a3cc59f4a