### PR TITLE
Fix optional requirements in ChatSidebar

### DIFF
--- a/components/ChatSidebar.tsx
+++ b/components/ChatSidebar.tsx
@@ -23,18 +23,18 @@ interface ModelRequirements {
   }[]
 }
 
-interface VisualizationModel {
-  id: string
-  name: string
-  description: string
-  icon: any
-  category: string
-  tags: string[]
-  complexity: "simple" | "medium" | "advanced"
-  prompt: string
-  requirements: ModelRequirements
-  disabled?: boolean
-}
+  interface VisualizationModel {
+    id: string
+    name: string
+    description: string
+    icon: any
+    category: string
+    tags: string[]
+    complexity: "simple" | "medium" | "advanced"
+    prompt: string
+    requirements?: ModelRequirements
+    disabled?: boolean
+  }
 
 const visualizationModels: VisualizationModel[] = [
   // Nuages de points (Scatter plots)
@@ -939,7 +939,7 @@ const checkModelCompatibility = (model: VisualizationModel, data: any[], columns
     return acc
   }, { numeric: [] as string[], temporal: [] as string[], categorical: [] as string[] })
 
-  const requirements = model.requirements
+  const requirements = model.requirements || {}
   
   // Vérifier les minimums requis
   if (requirements.minNumericColumns && columnTypes.numeric.length < requirements.minNumericColumns) return false


### PR DESCRIPTION
## Summary
- allow visualization models to omit requirements
- handle models without requirements during compatibility checks

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a665c210832ba93af9692c08fc1f